### PR TITLE
Fix: account for minutes affecting hour hand position; return smallest angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clock-angle
 
-Find angle between hour and minute hands
+Find smallest angle between hour and minute hands on the face of a standard 12-hr clock, in degrees
 
 # Install
 
@@ -22,9 +22,11 @@ clockAngle(null, 15) // 90
 clockAngle(null, 30) // 180
 
 // hour hand to minute hand
-clockAngle(0,15) // 90
-clockAngle(12,15) // 90
-clockAngle(9,15) // 180
+clockAngle(3, 0) // 90
+clockAngle(0, 15) // 82.5
+clockAngle(12, 15) // 82.5
+clockAngle(9, 15) // 172.5
+clockAngle(11, 59) // 5.5
 ```
 
 # License

--- a/clock-angle.js
+++ b/clock-angle.js
@@ -1,17 +1,32 @@
 (function(){
 
   function angleBtwnMinuteAnd12oclock(m) {
-    return 360 * m / 60;
+    m = m || 0;
+    m = m % 60;
+
+    return m * 6;
   }
 
   function angleBtwnHourAnd12oclock(h, m) {
     m = m || 0;
-    return 360 * (h % 12) / 12 + 360 * (m / 60) * (1 / 12);
+    h = h || 0;
+
+    m = m % 60;
+    h = h % 12;
+
+    return (h + (m / 60)) * 30;
   }
 
   function angleBtwnHourAndMinute(h, m) {
-    var r = (angleBtwnHourAnd12oclock(h) - angleBtwnMinuteAnd12oclock(m)) % 360;
-    return Math.abs(r);
+    if(h == null) return angleBtwnMinuteAnd12oclock(m) % 360;
+
+    return smallestAngle(angleBtwnHourAnd12oclock(h, m) - angleBtwnMinuteAnd12oclock(m));
+  }
+
+  function smallestAngle(d) {
+    d = Math.abs(d) % 360;
+
+    return (d < 180) ? d : 360 - d;
   }
 
   var clockAngle = function(h, m) {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/miguelmota/clock-angle",
   "dependencies": {
     "tape": "^3.0.3"
+  },
+  "devDependencies": {
+    "tape": "^3.5.0"
   }
 }

--- a/test/clock-angle.js
+++ b/test/clock-angle.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var clockAngle = require('../clock-angle');
 
 test('clock angle', function (t) {
-  t.plan(7);
+  t.plan(9);
 
   t.equal(clockAngle(3), 90);
   t.equal(clockAngle(6), 180);
@@ -10,7 +10,9 @@ test('clock angle', function (t) {
   t.equal(clockAngle(null, 15), 90);
   t.equal(clockAngle(null, 30), 180);
 
-  t.equal(clockAngle(0,15), 90);
-  t.equal(clockAngle(12,15), 90);
-  t.equal(clockAngle(9,15), 180);
+  t.equal(clockAngle(3, 0), 90);
+  t.equal(clockAngle(0, 15), 82.5);
+  t.equal(clockAngle(12, 15), 82.5);
+  t.equal(clockAngle(9, 15), 172.5);
+  t.equal(clockAngle(11, 59), 5.5);
 });


### PR DESCRIPTION
- Account for minutes (partial hours) when determining position of hour hand (fixes #1)
- Return the smallest angle made by the hands (<= 180 deg) (addresses #2)
- Updated / added additional tests
- Updated README to reflect fixes
